### PR TITLE
Points to the uncompressed dist version

### DIFF
--- a/component.json
+++ b/component.json
@@ -4,8 +4,8 @@
   "description": "The BriteJS library",
   "version": "1.1.1",
   "keywords": ["britejs"],
-  "main": "dist/brite.min.js",
+  "main": "dist/brite.js",
   "scripts": [
-    "dist/brite.min.js"
+    "dist/brite.js"
   ]
 }


### PR DESCRIPTION
Component dependencies should be left uncompressed to allow for consumers to debug issues if needed. It is also useful to let consumers of the component decide upon their compression and obfuscation strategies.
