### PR TITLE
Makes it possible to define callback function to use a custom folder structure

### DIFF
--- a/src/js/brite.core.js
+++ b/src/js/brite.core.js
@@ -259,8 +259,14 @@ if ( typeof module === "object" && module && typeof module.exports === "object" 
 					loadTemplateDfd = $.Deferred();
 					// if it is a string, then, it is the templatename, otherwise, the component name is the name
 					var templateName = (typeof loadTemplate == "string")?templateName:(name + ".html");
+					var url = null;
+					if (typeof brite.config.tmplPath === "function") {
+						url = brite.config.tmplPath(name);
+					}else{
+						url = brite.config.tmplPath + name + brite.config.tmplExt;
+					}
 					$.ajax({
-						url : brite.config.tmplPath + name + brite.config.tmplExt,
+						url : url,
 						async : true
 					}).complete(function(jqXHR, textStatus) {
 						$(brite.config.componentsHTMLHolder).append(jqXHR.responseText);
@@ -277,13 +283,18 @@ if ( typeof module === "object" && module && typeof module.exports === "object" 
 			if (loadCss){
 				//TODO: need to add the checkCss support
 				loadCssDfd = $.Deferred();
-				var cssFileName = brite.config.cssPath + name + ".css";
-				var includeDfd = includeFile(cssFileName,"css");
+				var url = null;
+				if (typeof brite.config.cssPath === "function") {
+					url = brite.config.cssPath(name);
+				}else{
+					url = brite.config.cssPath + name + ".css";
+				}
+				var includeDfd = includeFile(url,"css");
 				includeDfd.done(function(){
 					loadCssDfd.resolve();
 				}).fail(function(){
 					if (console){
-						console.log("Brite ERROR: cannot load " + cssFileName + ". Ignoring issue");
+						console.log("Brite ERROR: cannot load " + url + ". Ignoring issue");
 					}
 					loadCssDfd.resolve();
 				});      
@@ -317,7 +328,11 @@ if ( typeof module === "object" && module && typeof module.exports === "object" 
 		if (componentDef){
 			dfd.resolve(componentDef);
 		}else{
-			var resourceFile = brite.config.jsPath + name + ".js";
+			var resourceFile = null;
+			if (typeof brite.config.jsPath === "function")
+				resourceFile = brite.config.jsPath(name);
+			else
+				resourceFile = brite.config.jsPath + name + ".js";
 			var includeDfd = includeFile(resourceFile,"js");
 			includeDfd.done(function(){
 				componentDef = _componentDefStore[name];


### PR DESCRIPTION
Makes it possible to define callback function to use a custom folder structure e.g.: module based structure).

Simply by defining a function to generate the URL/Path based on the View's name. You could also do it by defining some new attributes in "config" object, but this was the easiest way :-)

``` javascript
// init with
brite.viewDefaultConfig.loadTmpl = true;
brite.viewDefaultConfig.loadCss = true;
brite.config.jsPath = function (viewName) {
    return 'views/' + viewName + '/' + viewName + '.js';
}
brite.config.tmplPath = function (viewName) {
    return 'views/' + viewName + '/' + viewName + '.tmpl';
}
brite.config.cssPath = function (viewName) {
    return 'views/' + viewName + '/' + viewName + '.css';
}
```

```
// for a folder structure like
/<PROJECT ROOT>
  /views
    /FirstView
      FirstView.js
      FirstView.tmpl
      FirstView.css
    /SecondView
      SecondView.js
      SecondView.tmpl
      SecondView.css
```
